### PR TITLE
Fixed typos and command line arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Six easy steps to activate your TPM on the Rapsberry Pi:
 * Step one:
   * Open a (whatever) term on your Pi.
 * Step two:
-run a "sudo rpi-update" 
+  * run a "sudo rpi-update"
 * Step three:
     * open the /boot/config.txt with "sudo nano /boot/config.txt"
     * activate SPI with
@@ -22,7 +22,7 @@ run a "sudo rpi-update"
   * plug your LetsTrust-TPM on the right position and reboot your Raspberry Pi
 * Step fife:
   * Open a (whatever) term on your Pi and type "ls /dev/tpm0" and
-/dev/tpm0 will appear in yellow letters!
+/dev/tpmrm0 will appear in yellow letters!
 * Step six:
   * Be happy about your success!
 
@@ -45,4 +45,4 @@ run a "sudo rpi-update"
 
 
 
-  [1] https://github.com/tpm2-software  
+  [1] https://github.com/tpm2-software

--- a/Scripts/tpm2_all.sh
+++ b/Scripts/tpm2_all.sh
@@ -55,17 +55,14 @@ echo "Hello TPM2 Cryptoworld!" >> input_data
 echo "File En/Decrypt"
 tpm2_createprimary -a e -g sha256 -G rsa -o primary_ctx -P "str:endorse"
 tpm2_create  -g sha256 -G rsa -C primary_ctx -u key_pub -r key_priv
-tpm2_loadexternal -a n -u key_pub -o rsaencrypt_key_ctx
-tpm2_rsaencrypt -c rsaencrypt_key_ctx -o cipher_data input_data
-tpm2_load -C primary_ctx  -u key_pub -r key_priv  -n name -o rsaencrypt_key_ctx
-tpm2_rsadecrypt -c rsaencrypt_key_ctx -I cipher_data -o output_data
-echo input_data
+tpm2_loadexternal -a n -u key_pub -o external_ctx
+tpm2_rsaencrypt -c external_ctx -o cipher_data input_data
+tpm2_load -C primary_ctx  -u key_pub -r key_priv  -n name -o load_ctx
+tpm2_rsadecrypt -c load_ctx -i cipher_data -o output_data
+cat output_data
 
 echo "ECC sign"
 tpm2_create  -g sha256 -G ecc -C primary_ctx -u key_pub_ecc -r key_priv_ecc
 tpm2_load -C primary_ctx  -u key_pub_ecc  -r key_priv_ecc -n name_ecc -o eccsigning_key_ctx
-tpm2_sign -c eccsigning_key_ctx -G sha256 -m input_data  -s signature
-tpm2_verifysignature  -c eccsigning_key_ctx -G sha256 -m input_data -s signature -t ticket_data
-
-
-
+tpm2_sign -c eccsigning_key_ctx -g sha256 -m input_data  -o signature
+tpm2_verifysignature  -c eccsigning_key_ctx -g sha256 -m input_data -s signature -t ticket_data


### PR DESCRIPTION
Using the same context file name for `tpm2_loadexternal` and `tpm2_load` resulted in the following warning for the `tpm2_load` command:
```
~$ tpm2_load -C primary_ctx  -u key_pub -r key_priv  -n name -o rsaencrypt_key_ctx
WARN: Path: rsaencrypt_key_ctx already exists. Please rename or delete the file!
transient-context: rsaencrypt_key_ctx1(null)
```
The object context of `tpm2_load` is then saved in a file called `rsaencrypt_key_ctx1(null)` leading to an error with the next command.