### PR TITLE
Update tpm2_install.sh

### DIFF
--- a/Scripts/tpm2_install.sh
+++ b/Scripts/tpm2_install.sh
@@ -39,6 +39,6 @@ echo "clone, compile and install the latest tpm2-tools version"
 git clone https://github.com/tpm2-software/tpm2-tools.git
 cd tpm2-tools
 ./bootstrap
-./configure
+CFLAGS="-Wno-error" ./configure
 make -j4
 sudo make install


### PR DESCRIPTION
Build of tpm2-tools now succeeds also when compiler warnings occur

Backround:

Building in RaspiOS (bookworm) does not succeed due to warnings issued about tpm2-tools. Warnings are handled as error and build fails.
(possible uninitialized variable ```dgst_len``` in lib/pcr.c and size mismatch during logging in lib/tpm2_policy.c (l94, l127)).

The sample script should work, regardless of warnings from the included software. 